### PR TITLE
color warning in the terminal

### DIFF
--- a/Kernel/Internal.wl
+++ b/Kernel/Internal.wl
@@ -139,6 +139,7 @@ Module[{libraryResources, lib},
 
 PreCompile[{directory_String, name_String}, path_] := 
 Module[{libraryResources, lib}, 
+	Echo["\033[1;44mPre compilation was initiated. Please wait...\033[1;0m"];
 	libraryResources = getLibraryResourcesDirectory[directory]; 
 	lib = FileNameJoin[{libraryResources, name <> "." <> Internal`DynamicLibraryExtension[]}]; 
 	If[


### PR DESCRIPTION
to warn users of a possible delays.
On Windows machines it take sometimes 40 sec to compile. 